### PR TITLE
[FIX] git-mig-auto-msg: accept more git remotes

### DIFF
--- a/git-mig-auto-msg
+++ b/git-mig-auto-msg
@@ -24,7 +24,10 @@ from subprocess import check_output
 import click
 
 remote = check_output(['git', 'remote', 'get-url', 'origin']).decode().strip()
-assert remote in {"git@github.com:odoo/upgrade.git", "git@github.com:odoo/saas-migration.git"}
+assert remote in {
+    "git@github.com:odoo/{}{}".format(s, t)
+    for s in {'upgrade', 'saas-migration'} for t in ['', '.git']
+}
 
 def rs(s):
     assert s


### PR DESCRIPTION
Some git remote URLs could, eventually, not end with '.git'.
ex:
  git@github.com:odoo/upgrade